### PR TITLE
Make starting the service idempotent

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,19 +80,17 @@ when 'debian'
 
   execute 'sudo initctl reload-configuration'
 
-  execute 'sudo start minecraft-server'
-
 when 'rhel', 'fedora'
 
-  template '/usr/lib/systemd/system/minecraft.service' do
+  template '/usr/lib/systemd/system/minecraft-server.service' do
     source 'minecraft-server.service.erb'
     owner 'root'
     group 'root'
     mode '0644'
   end
 
-  execute 'sudo systemctl enable minecraft'
+end
 
-  execute 'sudo systemctl start minecraft'
-
+service 'minecraft-server' do
+  action [:enable, :start]
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -27,16 +27,8 @@ describe 'minecraft-basic::default' do
     it { should be_listening }
   end
 
-  if os[:family] == 'redhat'
-    describe file('/usr/lib/systemd/system/minecraft.service') do
-      its(:content) { should match /minecraft/ }
-      it { should exist }
-    end
-
-  elsif %w(debian ubuntu).include?(os[:family])
-    describe file('/etc/init/minecraft-server.conf') do
-      its(:content) { should match /minecraft/ }
-      it { should exist }
-    end
+  describe service('minecraft-server') do
+    it { should be_enabled }
+    it { should be_running }
   end
 end


### PR DESCRIPTION
Fixes getting tripped up on the service start `execute` block when re-running TK converge & verify.
